### PR TITLE
Added flags for static linking

### DIFF
--- a/atlas-lapack.setup
+++ b/atlas-lapack.setup
@@ -1,19 +1,19 @@
 ;; -*- Hen -*-
 
-(define (dynld-name fn)		
-  (make-pathname #f fn ##sys#load-dynamic-extension))	
+(define (dynld-name fn)
+  (make-pathname #f fn ##sys#load-dynamic-extension))
 
 
 (define (atlas-try-compile header ldflags)
-  (and (try-compile 
-	(string-append "#include <stdlib.h>\n" 
-	               "#include " header "\n" 
+  (and (try-compile
+	(string-append "#include <stdlib.h>\n"
+	               "#include " header "\n"
 		       "int main() { clapack_sgetrf(0, 0, 0, NULL, 0, NULL) ; return 0; }\n")
 	ldflags: ldflags)
        ldflags ))
 
 
-(define-syntax atlas-test 
+(define-syntax atlas-test
   (syntax-rules ()
     ((_ (flags ...))
      (condition-case (atlas-try-compile flags ...)
@@ -22,18 +22,19 @@
 (define ld-options
   (or (atlas-test ("<atlas/clapack.h>"   " -llapack_atlas -latlas -lm"))
       (atlas-test ("<clapack.h>"         " -llapack_atlas -latlas -lm"))
-    
+
       (atlas-test ("<atlas/clapack.h>"   " -latlas -lm"))
       (atlas-test ("<clapack.h>"         " -latlas -lm"))
-    
+
       (atlas-test ("<atlas/clapack.h>"   " -llapack_atlas -latlas -lm -lg2c"))
       (atlas-test ("<clapack.h>"         " -llapack_atlas -latlas -lm -lg2c"))
-    
+
       (atlas-test ("<atlas/clapack.h>"   " -latlas -lm -lg2c"))
       (atlas-test ("<clapack.h>"         " -latlas -lm -lg2c"))
 
       (atlas-test ("<atlas/clapack.h>"   " -lsatlas -lm"))
       (atlas-test ("<clapack.h>"         " -lsatlas -lm"))
+      (atlas-test ("<clapack.h>"         " -llapack -lcblas -latlas -lm"))
 
       (error "unable to figure out location of ATLAS library")
       ))
@@ -42,7 +43,7 @@
 (compile -O3 -d0 -s atlas-lapack.scm -j atlas-lapack -L "\"" ,ld-options "\"" )
 (compile -O2 -d0 -s atlas-lapack.import.scm)
 
-(install-extension 
+(install-extension
  'atlas-lapack
  `(,(dynld-name "atlas-lapack") ,(dynld-name "atlas-lapack.import") )
  `((version 3.1)


### PR DESCRIPTION
E.g. if linking to liblapack.a / libcblas.a / libatlas.a
This was necessary to compile the egg on cygwin after building ATLAS
manually without any shared libraries (.dll or .so files).
As a minor note, I removed trailing whitespace (rather, vim did).
